### PR TITLE
weeks of year validation

### DIFF
--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
-        <text x="80" y="14">100%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
+        <text x="80" y="14">99%</text>
     </g>
 </svg>

--- a/iso_week_date/_utils.py
+++ b/iso_week_date/_utils.py
@@ -1,0 +1,84 @@
+from typing import Any, Callable, Type, TypeVar
+
+try:
+    from typing import Self  # type: ignore[attr-defined]
+except ImportError:
+    from typing_extensions import Self  # type: ignore[attr-defined]
+
+
+T = TypeVar("T")
+
+
+class classproperty:
+    """
+    Decorator to create a class level property. It allows to define a property at the
+    class level, which can be accessed without creating an instance of the class.
+
+    Arguments:
+        f: function to be decorated
+
+    Usage:
+    ```python
+    class CustomClass:
+
+        @classproperty
+        def my_property(cls: Type):
+            return "This is a class property."
+
+    # Access the class property without creating an instance
+    print(CustomClass.my_property)  # "This is a class property."
+    ```
+    """
+
+    def __init__(self: Self, f: Callable[[Type[T]], Any]):
+        """Initialize classproperty."""
+        self.f = f
+
+    def __get__(self: Self, obj: T, owner: Type[T]) -> Any:
+        """
+        Get the value of the class property.
+
+        Arguments:
+            obj: The instance of the class (ignored)
+            owner: The class that owns the property
+        """
+        return self.f(owner)
+
+
+def format_err_msg(_fmt: str, _value: str) -> str:  # pragma: no cover
+    """Format error message given a format and a value."""
+
+    return (
+        "Invalid isoweek date format. "
+        f"Format must match the '{_fmt}' pattern, "
+        "where:"
+        "\n- YYYY is a year between 0001 and 9999"
+        "\n- W is a literal character"
+        "\n- NN is a week number between 1 and 53"
+        "\n- D is a day number between 1 and 7"
+        f"\n but found {_value}"
+    )
+
+
+def p_of_year(year: int) -> int:
+    """Returns the day of the week of 31 December"""
+    return (year + year // 4 - year // 100 + year // 400) % 7
+
+
+def weeks_of_year(year: int) -> int:
+    """
+    Returns the max number of weeks in a year.
+
+    From wikipedia section on
+    [weeks per year](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year):
+
+    If p(y) = (y + y//4 - y//100 + y//400) % 7 then
+    weeks(y) = 52 + (p(y) ==4 or p(y-1) == 3)
+
+    Arguments:
+        year: Ordinal year number
+
+    Returns:
+        Number of weeks in the year (either 52 or 53)
+    """
+    return 52 + (p_of_year(year) == 4 or p_of_year(year - 1) == 3)

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -13,6 +13,7 @@ from iso_week_date import IsoWeek, IsoWeekDate
         (IsoWeek, "abcd-xyz", pytest.raises(ValueError)),
         (IsoWeek, "0000-W01", pytest.raises(ValueError)),
         (IsoWeek, "2023-W00", pytest.raises(ValueError)),
+        (IsoWeek, "2023-W53", pytest.raises(ValueError)),
         (IsoWeek, "2023-W54", pytest.raises(ValueError)),
         (IsoWeekDate, "2023-W01-1", do_not_raise()),
         (IsoWeekDate, "2000-W01-1", do_not_raise()),
@@ -27,38 +28,12 @@ from iso_week_date import IsoWeek, IsoWeekDate
 def test_validate(_cls, value, context):
     """Test validate method"""
     with context as exc_info:
-        _cls.validate(value)
+        _cls._validate(value)
 
     if exc_info:
-        assert "Invalid isoweek date format" in str(exc_info.value)
-
-
-@pytest.mark.parametrize(
-    "_cls, value, context",
-    [
-        (IsoWeek, "2023W01", do_not_raise()),
-        (IsoWeek, "2000W01", do_not_raise()),
-        (IsoWeek, "abcdxyz", pytest.raises(ValueError)),
-        (IsoWeek, "0000W01", pytest.raises(ValueError)),
-        (IsoWeek, "2023W00", pytest.raises(ValueError)),
-        (IsoWeek, "2023W54", pytest.raises(ValueError)),
-        (IsoWeekDate, "2023W011", do_not_raise()),
-        (IsoWeekDate, "2000W011", do_not_raise()),
-        (IsoWeekDate, "abcdxyz1", pytest.raises(ValueError)),
-        (IsoWeekDate, "0000W011", pytest.raises(ValueError)),
-        (IsoWeekDate, "2023W001", pytest.raises(ValueError)),
-        (IsoWeekDate, "2023W541", pytest.raises(ValueError)),
-        (IsoWeekDate, "2023W010", pytest.raises(ValueError)),
-        (IsoWeekDate, "2023W018", pytest.raises(ValueError)),
-    ],
-)
-def test_validate_compact(_cls, value, context):
-    """Test validate method"""
-    with context as exc_info:
-        _cls.validate_compact(value)
-
-    if exc_info:
-        assert "Invalid isoweek date format" in str(exc_info.value)
+        assert ("Invalid isoweek date format" in str(exc_info.value)) or (
+            "Invalid week number" in str(exc_info.value)
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/isoweek_test.py
+++ b/tests/isoweek_test.py
@@ -31,7 +31,7 @@ def test_init(value, context, err_msg):
     """Tests __init__ and _validate methods of IsoWeek class"""
 
     with context as exc_info:
-        IsoWeek(value, True)
+        IsoWeek(value)
 
     if exc_info:
         assert err_msg in str(exc_info.value)

--- a/tests/isoweekdate_test.py
+++ b/tests/isoweekdate_test.py
@@ -18,7 +18,7 @@ class CustomWeekDate(IsoWeekDate):
 customweekdate = CustomWeekDate("2023-W01-1")
 
 
-@pytest.mark.parametrize("isoweek", ("2023-W01", "2023-W02", "2023-W53"))
+@pytest.mark.parametrize("isoweek", ("2023-W01", "2023-W02", "2023-W52"))
 @pytest.mark.parametrize("weekday", range(1, 8))
 def test_property(isoweek, weekday):
     """Tests properties unique of IsoWeekDate class, namely day and isoweek"""


### PR DESCRIPTION
Implements check for weeks of the year so that `IsoWeek("2023-W53")` would raise an error as 2023 does not have 53 weeks