### PR TITLE
[Patch] Mypy compliant and imports

### DIFF
--- a/iso_week_date/_utils.py
+++ b/iso_week_date/_utils.py
@@ -1,15 +1,17 @@
-from typing import Any, Callable, Type, TypeVar
+import sys
+from typing import Callable, Generic, Type, TypeVar, Union
 
-try:
-    from typing import Self  # type: ignore[attr-defined]
-except ImportError:
-    from typing_extensions import Self  # type: ignore[attr-defined]
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 T = TypeVar("T")
+R = TypeVar("R")
 
 
-class classproperty:
+class classproperty(Generic[T, R]):
     """
     Decorator to create a class level property. It allows to define a property at the
     class level, which can be accessed without creating an instance of the class.
@@ -30,11 +32,11 @@ class classproperty:
     ```
     """
 
-    def __init__(self: Self, f: Callable[[Type[T]], Any]):
+    def __init__(self: Self, f: Callable[[Type[T]], R]) -> None:
         """Initialize classproperty."""
         self.f = f
 
-    def __get__(self: Self, obj: T, owner: Type[T]) -> Any:
+    def __get__(self: Self, obj: Union[T, None], owner: Type[T]) -> R:
         """
         Get the value of the class property.
 

--- a/iso_week_date/isoweek.py
+++ b/iso_week_date/isoweek.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
+import sys
 from datetime import date, datetime, timedelta
 from typing import Any, Generator, Iterable, Tuple, TypeVar, Union, overload
 
 from iso_week_date._patterns import ISOWEEK__DATE_FORMAT, ISOWEEK__FORMAT, ISOWEEK_PATTERN
 from iso_week_date.base import BaseIsoWeek
 
-try:
-    from typing import Self  # type: ignore[attr-defined]
-except ImportError:
-    from typing_extensions import Self  # type: ignore[attr-defined]
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 IsoWeek_T = TypeVar("IsoWeek_T", date, datetime, str, "IsoWeek")
 
@@ -81,6 +87,7 @@ class IsoWeek(BaseIsoWeek):
 
         return self.days[n - 1]
 
+    @override
     def to_datetime(self: Self, weekday: int = 1) -> datetime:  # type: ignore[override]
         """
         Converts `IsoWeek` to `datetime` object with the given weekday.
@@ -121,6 +128,7 @@ class IsoWeek(BaseIsoWeek):
 
         return super().to_datetime(f"{self.value_}-{weekday}")
 
+    @override
     def to_date(self: Self, weekday: int = 1) -> date:  # type: ignore[override]
         """
         Converts `IsoWeek` to `date` object with the given `weekday`.

--- a/iso_week_date/isoweekdate.py
+++ b/iso_week_date/isoweekdate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import date, datetime, timedelta
 from typing import Generator, TypeVar, Union
 
@@ -10,10 +11,10 @@ from iso_week_date._patterns import (
 )
 from iso_week_date.base import BaseIsoWeek
 
-try:
-    from typing import Self  # type: ignore[attr-defined]
-except ImportError:
-    from typing_extensions import Self  # type: ignore[attr-defined]
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 IsoWeekDate_T = TypeVar("IsoWeekDate_T", date, datetime, str, "IsoWeekDate")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 authors = [{name = "Francesco Bruzzesi"}]
 
 dependencies = [
-    "typing-extensions; python_version < '3.11'",
+    "typing-extensions; python_version < '3.12'",
 ]
 
 classifiers = [


### PR DESCRIPTION
PR fixes:
- Mypy errors on type hinting
- Converts version imports from 
    ```py
    try:
        ...
    except ImportError
       ...
    ```
    to 
    ```py
    if sys.version_info >= (3,  XY):
        ...
    else:
        ...
   ```