### PR TITLE
Extend `__add__` & `__sub__` to iterable(s)

### DIFF
--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
-        <text x="80" y="14">99%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
+        <text x="80" y="14">100%</text>
     </g>
 </svg>

--- a/docs/img/coverage.svg
+++ b/docs/img/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
-        <text x="80" y="14">100%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
+        <text x="80" y="14">99%</text>
     </g>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,6 @@ To get started with `IsoWeek` and `IsoWeekDate` classes please refer to the [qui
 
 To check examples on how to work with _pandas_ and _polars_ functionalities please refer to the [dataframe modules](user-guide/dataframe-modules.md) section.
 
-
 ## Contributing
 
 Please read the [contributing guidelines](contribute.md) in the documentation site.

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -9,8 +9,8 @@ The `IsoWeek` and `IsoWeekDate` classes both provide the following functionaliti
 - Parsing from string, date and datetime objects
 - Conversion to string, date and datetime objects
 - Comparison operations between `IsoWeek` (resp `IsoWeekDate`) objects
-- Addition with `int` and `timedelta` types
-- Subtraction with `int`, `timedelta` and `IsoWeek` (resp `IsoWeekDate`) types
+- Addition with `int`, `timedelta`, and  `Iterable[int | timedelta]` types
+- Subtraction with `int`, `timedelta`, `IsoWeek` (resp `IsoWeekDate`), and `Iterable[int | timedelta | IsoWeek]` types
 - Range between two `IsoWeek` (resp. `IsoWeekDate`) objects
 - `__next__` method to generate the next `IsoWeek` (resp. `IsoWeekDate`) object
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -29,6 +29,7 @@ An instance can be initialized from parsing multiple types:
     iw = IsoWeek("2023-W01")  # IsoWeek("2023-W01")
     iwd = IsoWeekDate("2023-W01-1")  # IsoWeekDate("2023-W01-1")
     ```
+
 === "`from_string`"
 
     ```py
@@ -162,19 +163,23 @@ Classes inheriting from `BaseIsoWeek` have to implement:
 === "Addition `+`"
 
     ```py
-    iw + 1 # IsoWeek("2023-W02")
-    iw + timedelta(weeks=2) # IsoWeek("2023-W03")
+    iw + 1  # IsoWeek("2023-W02")
+    iw + timedelta(weeks=2)  # IsoWeek("2023-W03")
 
-    iwd + 1 # IsoWeekDate("2023-W01-2")
-    iwd + timedelta(days=2) # IsoWeekDate("2023-W01-3")
+    tuple(iw + (1,2,3))  # (IsoWeek("2023-W02"), IsoWeek("2023-W03"), IsoWeek("2023-W04"))
+
+    iwd + 1  # IsoWeekDate("2023-W01-2")
+    iwd + timedelta(days=2)  # IsoWeekDate("2023-W01-3")
     ```
 
 === "Subtraction `-`"
 
     ```py
-    iw - 1 # IsoWeek("2022-W52")
-    iw - timedelta(weeks=2) # IsoWeek("2022-W51")
-    iw - IsoWeek("2022-W52") # 1
+    iw - 1  # IsoWeek("2022-W52")
+    iw - timedelta(weeks=2)  # IsoWeek("2022-W51")
+    iw - IsoWeek("2022-W52")  # 1
+
+    tuple(iw - (1,2,3))  # (IsoWeek("2022-W52"), IsoWeek("2022-W51"), IsoWeek("2022-W50"))
 
     iwd - 1 # IsoWeekDate("2022-W52-7")
     iwd - timedelta(days=2) # IsoWeekDate("2022-W52-6")

--- a/iso_week_date/_patterns.py
+++ b/iso_week_date/_patterns.py
@@ -19,9 +19,9 @@ WEEK_MATCH: Final[str] = r"(W0[1-9]|W[1-4]\d|W5[0-3])"
 WEEKDAY_MATCH: Final[str] = r"([1-7])"
 
 # Patterns
-ISOWEEK_PATTERN: Final[re.Pattern] = re.compile(r"^{}-{}$".format(YEAR_MATCH, WEEK_MATCH))
+ISOWEEK_PATTERN: Final[re.Pattern] = re.compile(rf"^{YEAR_MATCH}-{WEEK_MATCH}$")
 
-ISOWEEKDATE_PATTERN: Final[re.Pattern] = re.compile(r"^{}-{}-{}$".format(YEAR_MATCH, WEEK_MATCH, WEEKDAY_MATCH))
+ISOWEEKDATE_PATTERN: Final[re.Pattern] = re.compile(rf"^{YEAR_MATCH}-{WEEK_MATCH}-{WEEKDAY_MATCH}$")
 
 # !Remark: Compact patterns are obtained by removing the "-" separator between the groups
 # This is a hacky way to achieve this, but it avoids code replication and having to

--- a/iso_week_date/base.py
+++ b/iso_week_date/base.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import ClassVar, Generator, Iterable, Literal, Type, TypeVar, overload
+from typing import ClassVar, Generator, Iterable, Literal, Type, TypeVar, Union, overload
 
 from iso_week_date._utils import classproperty, format_err_msg, weeks_of_year
 from iso_week_date.mixin import ComparatorMixin, ConverterMixin, IsoWeekProtocol, ParserMixin
@@ -153,24 +153,24 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         return min((self.week - 1) // 13 + 1, 4)
 
     @overload
-    def __add__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __add__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @overload
-    def __add__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __add__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @abstractmethod
     def __add__(
-        self: Self, other: int | timedelta | Iterable[int | timedelta]
-    ) -> Self | Generator[Self, None, None]:  # pragma: no cover
+        self: Self, other: Union[int, timedelta, Iterable[Union[int, timedelta]]]
+    ) -> Union[Self, Generator[Self, None, None]]:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @overload
-    def __sub__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __sub__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Annotation for subtraction with `int` and `timedelta`"""
         ...
 
@@ -180,7 +180,7 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         ...
 
     @overload
-    def __sub__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __sub__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Annotation for subtraction with other `BaseIsoWeek`"""
         ...
 
@@ -191,8 +191,8 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
 
     @abstractmethod
     def __sub__(
-        self: Self, other: int | timedelta | Self | Iterable[int | timedelta | Self]
-    ) -> int | Self | Generator[int | timedelta | Self, None, None]:  # pragma: no cover
+        self: Self, other: Union[int, timedelta, Self, Iterable[Union[int, timedelta, Self]]]
+    ) -> Union[int, Self, Generator[Union[int, Self], None, None]]:  # pragma: no cover
         """Implementation of subtraction operator."""
         ...
 
@@ -208,7 +208,7 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         step: int = 1,
         inclusive: Literal["both", "left", "right", "neither"] = "both",
         as_str: bool = True,
-    ) -> Generator[str | Self, None, None]:
+    ) -> Generator[Union[str, Self], None, None]:
         """Generates `BaseIsoWeek` (or `str`) between `start` and `end` values with given `step`.
 
         `inclusive` parameter can be used to control inclusion of `start` and/or `end` week values.
@@ -267,7 +267,7 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         range_start = 0 if inclusive in ("both", "left") else 1
         range_end = _delta + 1 if inclusive in ("both", "right") else _delta
 
-        weeks_range: Generator[str | Self, None, None] = (
+        weeks_range: Generator[Union[str, Self], None, None] = (
             (_start + i).to_string() if as_str else _start + i for i in range(range_start, range_end, step)
         )
 

--- a/iso_week_date/base.py
+++ b/iso_week_date/base.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import ClassVar, Generator, Literal, Type, TypeVar, Union, overload
+from typing import ClassVar, Generator, Iterable, Literal, Type, TypeVar, overload
 
 from iso_week_date._utils import classproperty, format_err_msg, weeks_of_year
 from iso_week_date.mixin import ComparatorMixin, ConverterMixin, IsoWeekProtocol, ParserMixin
@@ -152,13 +152,25 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
 
         return min((self.week - 1) // 13 + 1, 4)
 
-    @abstractmethod
-    def __add__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
+    @overload
+    def __add__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @overload
-    def __sub__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
+    def __add__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+        """Implementation of addition operator."""
+        ...
+
+    @abstractmethod
+    def __add__(
+        self: Self, other: int | timedelta | Iterable[int | timedelta]
+    ) -> Self | Generator[Self, None, None]:  # pragma: no cover
+        """Implementation of addition operator."""
+        ...
+
+    @overload
+    def __sub__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
         """Annotation for subtraction with `int` and `timedelta`"""
         ...
 
@@ -167,8 +179,20 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         """Annotation for subtraction with other `BaseIsoWeek`"""
         ...
 
+    @overload
+    def __sub__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+        """Annotation for subtraction with other `BaseIsoWeek`"""
+        ...
+
+    @overload
+    def __sub__(self: Self, other: Iterable[Self]) -> Generator[int, None, None]:  # pragma: no cover
+        """Annotation for subtraction with other `Self`"""
+        ...
+
     @abstractmethod
-    def __sub__(self: Self, other: Union[int, timedelta, Self]) -> Union[int, Self]:  # pragma: no cover
+    def __sub__(
+        self: Self, other: int | timedelta | Self | Iterable[int | timedelta | Self]
+    ) -> int | Self | Generator[int | timedelta | Self, None, None]:  # pragma: no cover
         """Implementation of subtraction operator."""
         ...
 
@@ -184,7 +208,7 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         step: int = 1,
         inclusive: Literal["both", "left", "right", "neither"] = "both",
         as_str: bool = True,
-    ) -> Generator[Union[str, Self], None, None]:
+    ) -> Generator[str | Self, None, None]:
         """Generates `BaseIsoWeek` (or `str`) between `start` and `end` values with given `step`.
 
         `inclusive` parameter can be used to control inclusion of `start` and/or `end` week values.
@@ -243,7 +267,7 @@ class BaseIsoWeek(ABC, ComparatorMixin, ConverterMixin, ParserMixin):
         range_start = 0 if inclusive in ("both", "left") else 1
         range_end = _delta + 1 if inclusive in ("both", "right") else _delta
 
-        weeks_range: Generator[Union[str, Self], None, None] = (
+        weeks_range: Generator[str | Self, None, None] = (
             (_start + i).to_string() if as_str else _start + i for i in range(range_start, range_end, step)
         )
 

--- a/iso_week_date/isoweek.py
+++ b/iso_week_date/isoweek.py
@@ -301,7 +301,7 @@ class IsoWeek(BaseIsoWeek):
         ```
         """
         if not isinstance(n_weeks, int):
-            raise TypeError(f"`n_weeks` must be integer, found {type(n_weeks)} type")
+            raise TypeError(f"`n_weeks` must be an integer, found {type(n_weeks)} type")
 
         if n_weeks <= 0:
             raise ValueError(f"`n_weeks` must be strictly positive, found {n_weeks}")

--- a/iso_week_date/isoweek.py
+++ b/iso_week_date/isoweek.py
@@ -174,7 +174,7 @@ class IsoWeek(BaseIsoWeek):
             other: Object to add to `IsoWeek`.
 
         Returns:
-            New `IsoWeek` object or generator of `IsoWeek` objects with the result of the addition.
+            New `IsoWeek` or generator of `IsoWeek` object(s) with the result of the addition.
 
         Raises:
             TypeError: If `other` is not `int`, `timedelta` or `Iterable` of `int` and/or `timedelta`.
@@ -232,15 +232,17 @@ class IsoWeek(BaseIsoWeek):
         - `timedelta`: converts `IsoWeek` to datetime (first day of week), subtract `timedelta` and converts back to
             `IsoWeek` object.
         - `IsoWeek`: will result in the difference between values in weeks (`int` type).
+        - `Iterable` of `int`, `timedelta` and/or `IsoWeek`: subtracts each element of the iterable to the `IsoWeek`.
 
         Arguments:
             other: Object to subtract to `IsoWeek`.
 
         Returns:
-            Results from the subtraction, can be `int` or `IsoWeek` depending on the type of `other`.
+            Results from the subtraction, can be `int`, `IsoWeek` or Generator of `int` and/or `IsoWeek` depending
+                on the type of `other`.
 
         Raises:
-            TypeError: If `other` is not `int`, `timedelta` or `IsoWeek`.
+            TypeError: If `other` is not `int`, `timedelta`, `IsoWeek` or `Iterable` of those types.
 
         Examples:
         ```py

--- a/iso_week_date/isoweek.py
+++ b/iso_week_date/isoweek.py
@@ -183,6 +183,8 @@ class IsoWeek(BaseIsoWeek):
         IsoWeek("2023-W01") + 1  # IsoWeek("2023-W02")
         IsoWeek("2023-W01") + timedelta(weeks=2)  # IsoWeek("2023-W03")
         IsoWeek("2023-W01") + timedelta(hours=1234) # IsoWeek("2023-W08")
+
+        tuple(IsoWeek("2023-W01") + (1,2,3)) # (IsoWeek("2023-W02"), IsoWeek("2023-W03"), IsoWeek("2023-W04"))
         ```
         """
 
@@ -243,7 +245,9 @@ class IsoWeek(BaseIsoWeek):
 
         IsoWeek("2023-W01") - 1  # IsoWeek("2022-W52")
         IsoWeek("2023-W01") - timedelta(weeks=2)  # IsoWeek("2022-W51")
-        IsoWeek("2023-W01") - timedelta(hours=1234) # IsoWeek("2023-W45")
+        IsoWeek("2023-W01") - timedelta(hours=1234)  # IsoWeek("2023-W45")
+
+        tuple(IsoWeek("2023-W01") - (1,2,3))  # (IsoWeek("2022-W52"), IsoWeek("2022-W51"), IsoWeek("2022-W50"))
 
         IsoWeek("2023-W01") - IsoWeek("2022-W52")  # 1
         IsoWeek("2023-W01") - IsoWeek("2022-W51")  # 2

--- a/iso_week_date/isoweek.py
+++ b/iso_week_date/isoweek.py
@@ -150,30 +150,34 @@ class IsoWeek(BaseIsoWeek):
         return self.to_datetime(weekday).date()
 
     @overload
-    def __add__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __add__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @overload
-    def __add__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __add__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
-    def __add__(self: Self, other: int | timedelta | Iterable[int | timedelta]) -> Self | Generator[Self, None, None]:
-        """It supports addition with the following two types:
+    def __add__(
+        self: Self, other: Union[int, timedelta, Iterable[Union[int, timedelta]]]
+    ) -> Union[Self, Generator[Self, None, None]]:
+        """It supports addition with the following types:
 
         - `int`: interpreted as number of weeks to be added to the `IsoWeek` value.
         - `timedelta`: converts `IsoWeek` to datetime (first day of week), adds `timedelta` and converts back to
             `IsoWeek` object.
+        - `Iterable` of `int` and/or `timedelta`: adds each element of the iterable to the `IsoWeek` value and returns
+            a generator of `IsoWeek` objects.
 
         Arguments:
             other: Object to add to `IsoWeek`.
 
         Returns:
-            New `IsoWeek` object with the result of the addition.
+            New `IsoWeek` object or generator of `IsoWeek` objects with the result of the addition.
 
         Raises:
-            TypeError: If `other` is not `int` or `timedelta`.
+            TypeError: If `other` is not `int`, `timedelta` or `Iterable` of `int` and/or `timedelta`.
 
         Examples:
         ```py
@@ -200,7 +204,7 @@ class IsoWeek(BaseIsoWeek):
             )
 
     @overload
-    def __sub__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __sub__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Annotation for subtraction with `int` and `timedelta`"""
         ...
 
@@ -210,7 +214,7 @@ class IsoWeek(BaseIsoWeek):
         ...
 
     @overload
-    def __sub__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __sub__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Annotation for subtraction with other `BaseIsoWeek`"""
         ...
 
@@ -220,8 +224,8 @@ class IsoWeek(BaseIsoWeek):
         ...
 
     def __sub__(
-        self: Self, other: int | timedelta | Self | Iterable[int | timedelta | Self]
-    ) -> int | Self | Generator[int | timedelta | Self, None, None]:
+        self: Self, other: Union[int, timedelta, Self, Iterable[Union[int, timedelta, Self]]]
+    ) -> Union[int, Self, Generator[Union[int, Self], None, None]]:
         """It supports subtraction with the following types:
 
         - `int`: interpreted as number of weeks to be subtracted to the `IsoWeek` value.

--- a/iso_week_date/isoweekdate.py
+++ b/iso_week_date/isoweekdate.py
@@ -138,6 +138,8 @@ class IsoWeekDate(BaseIsoWeek):
 
         IsoWeekDate("2023-W01-1") + 1  # IsoWeekDate("2023-W01-2")
         IsoWeekDate("2023-W01-1") + timedelta(weeks=2)  # IsoWeekDate("2023-W03-1")
+
+        tuple(IsoWeekDate("2023-W01-1") + (1,2)) # (IsoWeekDate("2023-W01-2"), IsoWeekDate("2023-W01-3"))
         ```
         """
 
@@ -200,7 +202,10 @@ class IsoWeekDate(BaseIsoWeek):
         IsoWeekDate("2023-W01-1") - 1  # IsoWeekDate("2022-W52-7")
         IsoWeekDate("2023-W01-1") - timedelta(weeks=2)  # IsoWeekDate("2022-W51-1")
 
+        tuple(IsoWeekDate("2023-W01-1") - (1,2))  # (IsoWeekDate("2022-W52-7"), IsoWeekDate("2022-W52-6"))
+
         IsoWeekDate("2023-W01-1") - IsoWeekDate("2022-W52-3")  # 5
+
         ```
         """
 

--- a/iso_week_date/isoweekdate.py
+++ b/iso_week_date/isoweekdate.py
@@ -107,29 +107,33 @@ class IsoWeekDate(BaseIsoWeek):
         return self.to_datetime().date()
 
     @overload
-    def __add__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __add__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
     @overload
-    def __add__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __add__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Implementation of addition operator."""
         ...
 
-    def __add__(self: Self, other: int | timedelta | Iterable[int | timedelta]) -> Self | Generator[Self, None, None]:
-        """It supports addition with the following two types:
+    def __add__(
+        self: Self, other: Union[int, timedelta, Iterable[Union[int, timedelta]]]
+    ) -> Union[Self, Generator[Self, None, None]]:
+        """It supports addition with the following types:
 
         - `int`: interpreted as number of days to be added to the `IsoWeekDate` value.
         - `timedelta`: converts `IsoWeekDate` to `datetime`, adds `timedelta` and converts back to `IsoWeekDate` object.
+        - `Iterable` of `int` and/or `timedelta`: adds each element of the iterable to the `IsoWeekDate` value and
+            returns a generator of `IsoWeekDate` objects.
 
         Arguments:
             other: Object to add to `IsoWeekDate`.
 
         Returns:
-            New `IsoWeekDate` object with the result of the addition.
+            New `IsoWeekDate` or generator of `IsoWeekDate` object(s) with the result of the addition.
 
         Raises:
-            TypeError: If `other` is not `int` or `timedelta`.
+            TypeError: If `other` is not `int`, `timedelta` or `Iterable` of `int` and/or `timedelta`.
 
         Examples:
         ```py
@@ -156,7 +160,7 @@ class IsoWeekDate(BaseIsoWeek):
             )
 
     @overload
-    def __sub__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+    def __sub__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
         """Annotation for subtraction with `int` and `timedelta`"""
         ...
 
@@ -166,7 +170,7 @@ class IsoWeekDate(BaseIsoWeek):
         ...
 
     @overload
-    def __sub__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+    def __sub__(self: Self, other: Iterable[Union[int, timedelta]]) -> Generator[Self, None, None]:  # pragma: no cover
         """Annotation for subtraction with other `BaseIsoWeek`"""
         ...
 
@@ -176,23 +180,27 @@ class IsoWeekDate(BaseIsoWeek):
         ...
 
     def __sub__(
-        self: Self, other: int | timedelta | Self | Iterable[int | timedelta | Self]
-    ) -> int | Self | Generator[int | timedelta | Self, None, None]:
+        self: Self, other: Union[int, timedelta, Self, Iterable[Union[int, timedelta, Self]]]
+    ) -> Union[int, Self, Generator[Union[int, Self], None, None]]:
         """It supports subtraction with the following types:
 
         - `int`: interpreted as number of days to be subtracted to the `IsoWeekDate` value.
         - `timedelta`: converts `IsoWeekDate` to `datetime`, subtracts `timedelta` and converts back to `IsoWeekDate`
             object.
         - `IsoWeekDate`: will result in the difference between values in days (`int` type).
+        - `Iterable` of `int`, `timedelta` and/or `IsoWeekDate`: subtracts each element of the iterable to the
+            `IsoWeekDate`.
 
         Arguments:
             other: Object to subtract to `IsoWeekDate`.
 
         Returns:
-            Results from the subtraction, can be `int` or `IsoWeekDate` depending on the type of `other`.
+            Results from the subtraction, can be `int`, `IsoWeekDate` or Generator of `int` and/or `IsoWeekDate`
+                depending on the type of `other`.
+
 
         Raises:
-            TypeError: If `other` is not `int`, `timedelta` or `IsoWeekDate`.
+            TypeError: If `other` is not `int`, `timedelta`, `IsoWeekDate` or `Iterable` of those types.
 
         Examples:
         ```py

--- a/iso_week_date/isoweekdate.py
+++ b/iso_week_date/isoweekdate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime, timedelta
-from typing import Generator, TypeVar, Union, overload
+from typing import Generator, Iterable, TypeVar, Union, overload
 
 from iso_week_date._patterns import ISOWEEKDATE__DATE_FORMAT, ISOWEEKDATE__FORMAT, ISOWEEKDATE_PATTERN
 from iso_week_date.base import BaseIsoWeek
@@ -106,7 +106,17 @@ class IsoWeekDate(BaseIsoWeek):
         """
         return self.to_datetime().date()
 
-    def __add__(self: Self, other: Union[int, timedelta]) -> IsoWeekDate:
+    @overload
+    def __add__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+        """Implementation of addition operator."""
+        ...
+
+    @overload
+    def __add__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+        """Implementation of addition operator."""
+        ...
+
+    def __add__(self: Self, other: int | timedelta | Iterable[int | timedelta]) -> Self | Generator[Self, None, None]:
         """It supports addition with the following two types:
 
         - `int`: interpreted as number of days to be added to the `IsoWeekDate` value.
@@ -135,6 +145,8 @@ class IsoWeekDate(BaseIsoWeek):
             return self.from_date(self.to_date() + timedelta(days=other))
         elif isinstance(other, timedelta):
             return self.from_datetime(self.to_datetime() + other)
+        elif isinstance(other, Iterable) and all(isinstance(_other, (int, timedelta)) for _other in other):
+            return (self + _other for _other in other)
         else:
             raise TypeError(
                 f"Cannot add type {type(other)} to `IsoWeekDate`. "
@@ -142,16 +154,28 @@ class IsoWeekDate(BaseIsoWeek):
             )
 
     @overload
-    def __sub__(self: Self, other: Union[int, timedelta]) -> Self:  # pragma: no cover
-        """Annotation for subtraction with `int` and `timedelta`."""
+    def __sub__(self: Self, other: int | timedelta) -> Self:  # pragma: no cover
+        """Annotation for subtraction with `int` and `timedelta`"""
         ...
 
     @overload
     def __sub__(self: Self, other: Self) -> int:  # pragma: no cover
-        """Annotation for subtraction with other `BaseIsoWeek`."""
+        """Annotation for subtraction with other `BaseIsoWeek`"""
         ...
 
-    def __sub__(self: Self, other: Union[int, timedelta, Self]) -> Union[int, Self]:
+    @overload
+    def __sub__(self: Self, other: Iterable[int | timedelta]) -> Generator[Self, None, None]:  # pragma: no cover
+        """Annotation for subtraction with other `BaseIsoWeek`"""
+        ...
+
+    @overload
+    def __sub__(self: Self, other: Iterable[Self]) -> Generator[int, None, None]:  # pragma: no cover
+        """Annotation for subtraction with other `Self`"""
+        ...
+
+    def __sub__(
+        self: Self, other: int | timedelta | Self | Iterable[int | timedelta | Self]
+    ) -> int | Self | Generator[int | timedelta | Self, None, None]:
         """It supports subtraction with the following types:
 
         - `int`: interpreted as number of days to be subtracted to the `IsoWeekDate` value.
@@ -186,6 +210,8 @@ class IsoWeekDate(BaseIsoWeek):
             return self.from_datetime(self.to_datetime() - other)
         elif isinstance(other, IsoWeekDate) and self.offset_ == other.offset_:
             return (self.to_date() - other.to_date()).days
+        elif isinstance(other, Iterable) and all(isinstance(_other, (int, timedelta, IsoWeekDate)) for _other in other):
+            return (self - _other for _other in other)
         else:
             raise TypeError(
                 f"Cannot subtract type {type(other)} to `IsoWeekDate`. "

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -67,17 +67,12 @@ theme:
 # Plugins
 plugins:
   - autorefs
-  - mike:
-      alias_type: symlink
-      canonical_version: latest
   - mkdocstrings
   - search:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
 
 # Customization
 extra:
-  version:
-    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/fbruzzesi

--- a/tests/isoweek_test.py
+++ b/tests/isoweek_test.py
@@ -32,7 +32,6 @@ def test_init(value, context, err_msg):
 
     with context as exc_info:
         IsoWeek(value)
-
     if exc_info:
         assert err_msg in str(exc_info.value)
 
@@ -59,18 +58,18 @@ def test_quarters():
     "n, context, err_msg",
     [
         (1, do_not_raise(), ""),
-        (1.0, pytest.raises(TypeError), "n must be an integer"),
-        (-1, pytest.raises(ValueError), "n must be between 1 and 7"),
-        (8, pytest.raises(ValueError), "n must be between 1 and 7"),
+        (1.0, pytest.raises(TypeError), "`n` must be an integer"),
+        (-1, pytest.raises(ValueError), "`n` must be between 1 and 7"),
+        (8, pytest.raises(ValueError), "`n` must be between 1 and 7"),
     ],
 )
-def test_nth(capsys, n, context, err_msg):
+def test_nth(n, context, err_msg):
     """Tests nth method of IsoWeek class"""
-    with context:
+    with context as exc_info:
         isoweek.nth(n)
 
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 def test_str_repr():
@@ -83,18 +82,18 @@ def test_str_repr():
     "weekday, context, err_msg",
     [
         (1, do_not_raise(), ""),
-        (1.0, pytest.raises(TypeError), "weekday must be an integer"),
-        (-1, pytest.raises(ValueError), "weekday must be between 1 and 7"),
-        (8, pytest.raises(ValueError), "weekday must be between 1 and 7"),
+        (1.0, pytest.raises(TypeError), "`weekday` must be an integer"),
+        (-1, pytest.raises(ValueError), "Weekday must be between 1 and 7"),
+        (8, pytest.raises(ValueError), "Weekday must be between 1 and 7"),
     ],
 )
-def test_to_datetime_raise(capsys, weekday, context, err_msg):
+def test_to_datetime_raise(weekday, context, err_msg):
     """Tests to_datetime method of IsoWeek class"""
-    with context:
+    with context as exc_info:
         isoweek.to_datetime(weekday)
 
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -102,16 +101,19 @@ def test_to_datetime_raise(capsys, weekday, context, err_msg):
     [
         (1, do_not_raise(), ""),
         (timedelta(weeks=2), do_not_raise(), ""),
+        ((1, 2, timedelta(weeks=2)), do_not_raise(), ""),
         (1.0, pytest.raises(TypeError), "Cannot add type"),
         ("1", pytest.raises(TypeError), "Cannot add type"),
+        (("1", 2), pytest.raises(TypeError), "Cannot add type"),
     ],
 )
-def test_addition(capsys, value, context, err_msg):
+def test_addition(value, context, err_msg):
     """Tests addition operator of IsoWeek class"""
-    with context:
+    with context as exc_info:
         isoweek + value
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -123,16 +125,19 @@ def test_addition(capsys, value, context, err_msg):
         (IsoWeek("2023-W01"), do_not_raise(), ""),
         (IsoWeek("2023-W02"), do_not_raise(), ""),
         (IsoWeek("2022-W52"), do_not_raise(), ""),
-        (customweek, pytest.raises(TypeError), "Cannot add type"),
-        ("1", pytest.raises(TypeError), "Cannot add type"),
+        ((1, timedelta(weeks=2), IsoWeek("2022-W52")), do_not_raise(), ""),
+        (customweek, pytest.raises(TypeError), "Cannot subtract type"),
+        ("1", pytest.raises(TypeError), "Cannot subtract type"),
+        (("1", 2), pytest.raises(TypeError), "Cannot subtract type"),
     ],
 )
-def test_subtraction(capsys, value, context, err_msg):
+def test_subtraction(value, context, err_msg):
     """Tests subtraction operator of IsoWeek class"""
-    with context:
+    with context as exc_info:
         isoweek - value
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -157,14 +162,14 @@ def test_subtraction_return_type(value, return_type):
         (1, pytest.raises(NotImplementedError), "Cannot cast type"),
     ],
 )
-def test_automatic_cast(capsys, value, context, err_msg):
+def test_automatic_cast(value, context, err_msg):
     """Tests automatic casting of IsoWeek class"""
 
-    with context:
-        r = IsoWeek._cast(value)
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
-        assert isinstance(r, IsoWeek)
+    with context as exc_info:
+        _ = IsoWeek._cast(value)
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -173,18 +178,20 @@ def test_automatic_cast(capsys, value, context, err_msg):
         (1, 1, do_not_raise(), ""),
         (1, 2, do_not_raise(), ""),
         (10, 1, do_not_raise(), ""),
-        (1.0, 1, pytest.raises(TypeError), "n_weeks must be an integer"),
-        (0, 1, pytest.raises(ValueError), "n_weeks must be strictly positive"),
-        (-2, 1, pytest.raises(ValueError), "n_weeks must be strictly positive"),
+        (1.0, 1, pytest.raises(TypeError), "`n_weeks` must be an integer"),
+        (0, 1, pytest.raises(ValueError), "`n_weeks` must be strictly positive"),
+        (-2, 1, pytest.raises(ValueError), "`n_weeks` must be strictly positive"),
     ],
 )
-def test_weeksout(capsys, n_weeks, step, context, err_msg):
+def test_weeksout(n_weeks, step, context, err_msg):
     """Tests weeksout method of IsoWeek class"""
 
-    with context:
+    with context as exc_info:
         r = isoweek.weeksout(n_weeks, step)
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
+    else:
         assert isinstance(r, Generator)
 
 
@@ -203,13 +210,15 @@ def test_weeksout(capsys, n_weeks, step, context, err_msg):
         (123, None, pytest.raises(TypeError), "Cannot compare type"),
     ],
 )
-def test__contains__(capsys, other, expected, context, err_msg):
+def test__contains__(other, expected, context, err_msg):
     """Tests __contains__ method of IsoWeek class"""
 
-    with context:
+    with context as exc_info:
         r = other in isoweek
-        sys_out, _ = capsys.readouterr()
-        assert err_msg in sys_out
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
+    else:
         assert r == expected
 
 
@@ -223,10 +232,10 @@ def test__contains__(capsys, other, expected, context, err_msg):
         (123, None, pytest.raises(TypeError), "Cannot compare type"),
     ],
 )
-def test_contains_method(capsys, other, expected, context, err_msg):
+def test_contains_method(other, expected, context, err_msg):
     """Tests contains method of IsoWeek class"""
 
-    with context:
+    with context as exc_info:
         r = isoweek.contains(other)
 
         if isinstance(other, (date, datetime, str, IsoWeek)):
@@ -238,6 +247,5 @@ def test_contains_method(capsys, other, expected, context, err_msg):
             assert all(isinstance(v, bool) for v in r)
             assert r == expected
 
-        else:
-            sys_out, _ = capsys.readouterr()
-            assert err_msg in sys_out
+    if exc_info:
+        assert err_msg in str(exc_info.value)

--- a/tests/isoweekdate_test.py
+++ b/tests/isoweekdate_test.py
@@ -28,33 +28,47 @@ def test_property(isoweek, weekday):
 
 
 @pytest.mark.parametrize(
-    "other, expected, context",
+    "value, context, err_msg",
     [
-        (1, "2023-W01-2", do_not_raise()),
-        (timedelta(weeks=2), "2023-W03-1", do_not_raise()),
-        (1.0, None, pytest.raises(TypeError)),
+        (1, do_not_raise(), ""),
+        (timedelta(weeks=2), do_not_raise(), ""),
+        ((1, 2, timedelta(weeks=2)), do_not_raise(), ""),
+        (1.0, pytest.raises(TypeError), "Cannot add type"),
+        ("1", pytest.raises(TypeError), "Cannot add type"),
+        (("1", 2), pytest.raises(TypeError), "Cannot add type"),
     ],
 )
-def test_addition(other, expected, context):
-    """Tests addition of IsoWeekDate with other types"""
-    with context:
-        assert isoweekdate + other == IsoWeekDate(expected)
-        assert customweekdate + other == CustomWeekDate(expected)
+def test_addition(value, context, err_msg):
+    """Tests addition operator of IsoWeek class"""
+    with context as exc_info:
+        isoweekdate + value
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
-    "other, expected, context",
+    "value, context, err_msg",
     [
-        (1, "2022-W52-7", do_not_raise()),
-        (timedelta(weeks=2), "2022-W51-1", do_not_raise()),
-        (1.0, None, pytest.raises(TypeError)),
+        (1, do_not_raise(), ""),
+        (-1, do_not_raise(), ""),
+        (timedelta(days=2), do_not_raise(), ""),
+        (IsoWeekDate("2023-W01-2"), do_not_raise(), ""),
+        (IsoWeekDate("2023-W02-1"), do_not_raise(), ""),
+        (IsoWeekDate("2022-W52-1"), do_not_raise(), ""),
+        ((1, timedelta(weeks=2), IsoWeekDate("2022-W52-1")), do_not_raise(), ""),
+        (customweekdate, pytest.raises(TypeError), "Cannot subtract type"),
+        ("1", pytest.raises(TypeError), "Cannot subtract type"),
+        (("1", 2), pytest.raises(TypeError), "Cannot subtract type"),
     ],
 )
-def test_subtraction(other, expected, context):
-    """Tests subtraction of IsoWeekDate with other types"""
-    with context:
-        assert isoweekdate - other == IsoWeekDate(expected)
-        assert customweekdate - other == CustomWeekDate(expected)
+def test_subtraction(value, context, err_msg):
+    """Tests subtraction operator of IsoWeek class"""
+    with context as exc_info:
+        isoweekdate - value
+
+    if exc_info:
+        assert err_msg in str(exc_info.value)
 
 
 def test_sub_isoweekdate():


### PR DESCRIPTION
# Description

Allows to add and subtract an iterable to `IsoWeek `and `IsoWeekDate` objects.

Fix #58 