### PR TITLE
fix: `Expr.iwd.isoweek_to_datetime` in `with_columns` context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "iso-week-date"
-version = "1.3.0"
+version = "1.4.0"
 description = "Toolkit to work with str representing ISO Week date format"
 
 license = {file = "LICENSE"}
@@ -93,7 +93,8 @@ ignore = [
     "ISC001",  # Checks for implicitly concatenated strings on a single line.
     "RET505",  # Checks for else statements with a return statement in the preceding if block.
     "TRY003",  # Checks for long exception messages that are not defined in the exception class itself.
-    "DTZ"
+    "DTZ",
+    "COM812",
     ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/pandas_utils_test.py
+++ b/tests/pandas_utils_test.py
@@ -144,7 +144,6 @@ def test_isoweekdate_to_datetime(periods, offset):
 @pytest.mark.parametrize(
     "kwargs, context",
     [
-        ({"series": pd.DataFrame()}, pytest.raises(TypeError, match="`series` must be of type `pd.Series`")),
         (
             {"series": pd.Series(["2023-W01", "2023-W02"]), "offset": "abc"},
             pytest.raises(TypeError, match="`offset` must be of type `pd.Timedelta` or `int`"),
@@ -155,7 +154,7 @@ def test_isoweekdate_to_datetime(periods, offset):
         ),
         (
             {"series": pd.Series(["2023-Wab", "2023-W02"]), "weekday": 1},
-            pytest.raises(ValueError, match="`series` values must match ISO Week date format"),
+            pytest.raises(ValueError, match='time data "2023-Wab-1" doesn\'t match format'),
         ),
     ],
 )
@@ -169,12 +168,8 @@ def test_isoweek_to_datetime_raise(kwargs, context):
     "kwargs, context",
     [
         (
-            {"series": pd.DataFrame()},
-            pytest.raises(TypeError, match="`series` must be of type `pd.Series`"),
-        ),
-        (
             {"series": pd.Series(["2023-W01-a", "2023-W02-b"]), "offset": 1},
-            pytest.raises(ValueError, match="`series` values must match ISO Week date format"),
+            pytest.raises(ValueError, match='time data "2023-W01-a" doesn\'t match format'),
         ),
         (
             {"series": pd.Series(["2023-W01-1", "2023-W02-1"]), "offset": "abc"},

--- a/tests/polars_utils_test.py
+++ b/tests/polars_utils_test.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 import polars as pl
 import pytest
-from polars.exceptions import ComputeError
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
 
 from iso_week_date import IsoWeek, IsoWeekDate
@@ -152,7 +152,7 @@ def test_isoweekdate_to_datetime(periods, offset):
         ),
         (
             {"series": pl.Series(["2023-Wab", "2023-W02"]), "weekday": 1},
-            pytest.raises(ComputeError, match="conversion from `str` to `date` failed in column ''"),
+            pytest.raises(InvalidOperationError, match="conversion from `str` to `date` failed in column ''"),
         ),
     ],
 )
@@ -167,7 +167,7 @@ def test_isoweek_to_datetime_raise(kwargs, context):
     [
         (
             {"series": pl.Series(["2023-W01-a", "2023-W02-b"]), "offset": 1},
-            pytest.raises(ComputeError, match="conversion from `str` to `date` failed in column ''"),
+            pytest.raises(InvalidOperationError, match="conversion from `str` to `date` failed in column ''"),
         ),
         (
             {"series": pl.Series(["2023-W01-1", "2023-W02-1"]), "offset": "abc"},

--- a/tests/polars_utils_test.py
+++ b/tests/polars_utils_test.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 
 import polars as pl
 import pytest
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 from iso_week_date import IsoWeek, IsoWeekDate
@@ -142,10 +143,6 @@ def test_isoweekdate_to_datetime(periods, offset):
     "kwargs, context",
     [
         (
-            {"series": pl.DataFrame()},
-            pytest.raises(TypeError, match="`series` must be of type `pl.Series`"),
-        ),
-        (
             {"series": pl.Series(["2023-W01", "2023-W02"]), "offset": "abc"},
             pytest.raises(TypeError, match="`offset` must be of type `timedelta` or `int`"),
         ),
@@ -155,7 +152,7 @@ def test_isoweekdate_to_datetime(periods, offset):
         ),
         (
             {"series": pl.Series(["2023-Wab", "2023-W02"]), "weekday": 1},
-            pytest.raises(ValueError, match="`series` values must match ISO Week format"),
+            pytest.raises(ComputeError, match="conversion from `str` to `date` failed in column ''"),
         ),
     ],
 )
@@ -169,12 +166,8 @@ def test_isoweek_to_datetime_raise(kwargs, context):
     "kwargs, context",
     [
         (
-            {"series": pl.DataFrame()},
-            pytest.raises(TypeError, match="`series` must be of type `pl.Series`"),
-        ),
-        (
             {"series": pl.Series(["2023-W01-a", "2023-W02-b"]), "offset": 1},
-            pytest.raises(ValueError, match="`series` values must match ISO Week date format"),
+            pytest.raises(ComputeError, match="conversion from `str` to `date` failed in column ''"),
         ),
         (
             {"series": pl.Series(["2023-W01-1", "2023-W02-1"]), "offset": "abc"},


### PR DESCRIPTION
# Description

Fixes #83 by delegating the check to the conversion directly.
Additionally adds a `strict` flag