### PR TITLE
perf: skip validation in `from_date` and `from_datetime`

### DIFF
--- a/iso_week_date/_base.py
+++ b/iso_week_date/_base.py
@@ -70,7 +70,7 @@ class BaseIsoWeek(ABC):
         Raises:
             ValueError: If `value` does not match the `_pattern` pattern of the class.
         """
-        self.value_: str = self._validate(value)
+        self.value_ = self._validate(value)
 
     @classmethod
     def _validate(cls: type[Self], value: str) -> str:
@@ -212,6 +212,7 @@ class BaseIsoWeek(ABC):
         if not isinstance(_date, date):
             msg = f"Expected `date` type, found {type(_date)}"
             raise TypeError(msg)
+
         new_instance = cls.__new__(cls)
         new_instance.value_ = (_date - cls.offset_).strftime(cls._date_format)
         return new_instance

--- a/iso_week_date/_base.py
+++ b/iso_week_date/_base.py
@@ -212,7 +212,9 @@ class BaseIsoWeek(ABC):
         if not isinstance(_date, date):
             msg = f"Expected `date` type, found {type(_date)}"
             raise TypeError(msg)
-        return cls((_date - cls.offset_).strftime(cls._date_format))
+        new_instance = cls.__new__(cls)
+        new_instance.value_ = (_date - cls.offset_).strftime(cls._date_format)
+        return new_instance
 
     @classmethod
     def from_datetime(cls: type[Self], _datetime: datetime) -> Self:
@@ -221,7 +223,9 @@ class BaseIsoWeek(ABC):
             msg = f"Expected `datetime` type, found {type(_datetime)}"
             raise TypeError(msg)
 
-        return cls((_datetime - cls.offset_).strftime(cls._date_format))
+        new_instance = cls.__new__(cls)
+        new_instance.value_ = (_datetime - cls.offset_).strftime(cls._date_format)
+        return new_instance
 
     @classmethod
     def from_today(cls: type[Self]) -> Self:  # pragma: no cover


### PR DESCRIPTION
Skip string validation in `from_date` and `from_datetime`.

This makes a bunch of operations (those involving arithmetic ops) much more performant (~25%)

<details>
    <summary>Script to replicate</summary>

```py
import time
import numpy as np
from iso_week_date import IsoWeek

isoweek = IsoWeek("2023-W01")

low = 2023*52
high = (9999-2024)*52

size = 5_00_000

random_weeks = np.random.randint(low=low, high=high, size=size).tolist()

start = time.perf_counter()

_ = [isoweek + i for i in random_weeks]

end = time.perf_counter()
print(f"Time taken: {end - start:.4f} seconds")
```

main: 5.23 secs
branch: 3.906 secs
</details>