### PR TITLE
fix: Correct `daysout`/`to_compact` docs, guard non-int weekday, close test gaps

### DIFF
--- a/src/iso_week_date/isoweek.py
+++ b/src/iso_week_date/isoweek.py
@@ -531,7 +531,7 @@ class IsoWeek(BaseIsoWeek):
             `IsoWeek` value in `datetime` type with the given weekday.
 
         Raises:
-            TypeError: If `weekday` is not an integer.
+            TypeError: If `weekday` is not an integer (`bool` is not accepted).
             ValueError: If `weekday` is not between 1 and 7.
 
         Examples:
@@ -542,7 +542,9 @@ class IsoWeek(BaseIsoWeek):
             >>> IsoWeek("2025-W01").to_datetime(3)
             datetime.datetime(2025, 1, 1, 0, 0)
         """
-        if not isinstance(weekday, int):
+        # `bool` is excluded explicitly: `isinstance(True, int)` and `True in range(1, 8)` both hold,
+        # so a bare range check would interpolate the literal string "True" into the parsed value.
+        if not isinstance(weekday, int) or isinstance(weekday, bool):
             msg = f"`weekday` must be an integer between 1 and 7, found {type(weekday)}"
             raise TypeError(msg)
         if weekday not in range(1, 8):
@@ -567,7 +569,7 @@ class IsoWeek(BaseIsoWeek):
             `IsoWeek` value in `date` type with the given weekday.
 
         Raises:
-            TypeError: If `weekday` is not an integer.
+            TypeError: If `weekday` is not an integer (`bool` is not accepted).
             ValueError: If `weekday` is not between 1 and 7.
 
         Examples:
@@ -1025,7 +1027,7 @@ class IsoWeek(BaseIsoWeek):
             `date` object representing the Nth day of the week.
 
         Raises:
-            TypeError: If `n` is not an integer.
+            TypeError: If `n` is not an integer (`bool` is not accepted).
             ValueError: If `n` is not between 1 and 7.
 
         Examples:
@@ -1036,7 +1038,9 @@ class IsoWeek(BaseIsoWeek):
             >>> IsoWeek("2025-W01").nth(7)
             datetime.date(2025, 1, 5)
         """
-        if not isinstance(n, int):
+        # `bool` is rejected for consistency with `to_datetime`: a weekday is not a truth value, and
+        # accepting it here while rejecting it there would be the surprising half of the pair.
+        if not isinstance(n, int) or isinstance(n, bool):
             msg = f"`n` must be an integer, found {type(n)}"
             raise TypeError(msg)
         if n not in range(1, 8):

--- a/src/iso_week_date/isoweekdate.py
+++ b/src/iso_week_date/isoweekdate.py
@@ -529,7 +529,7 @@ class IsoWeekDate(BaseIsoWeek):
         return super().to_string()
 
     def to_compact(self: Self) -> str:
-        """Returns as a string in the YYYYWNN format.
+        """Returns as a string in the YYYYWNND format.
 
         Examples:
             >>> from iso_week_date import IsoWeekDate
@@ -1062,11 +1062,11 @@ class IsoWeekDate(BaseIsoWeek):
             ('2025-W01-2', '2025-W01-4', '2025-W01-6')
         """
         if not isinstance(n_days, int):
-            msg = f"`n_weeks` must be integer, found {type(n_days)} type"
+            msg = f"`n_days` must be integer, found {type(n_days)} type"
             raise TypeError(msg)
 
         if n_days <= 0:
-            msg = f"`n_weeks` must be strictly positive, found {n_days}"
+            msg = f"`n_days` must be strictly positive, found {n_days}"
             raise ValueError(msg)
 
         start, end = (self + 1), (self + n_days)

--- a/src/iso_week_date/pandas_utils.py
+++ b/src/iso_week_date/pandas_utils.py
@@ -159,6 +159,7 @@ def isoweek_to_datetime(
 
             * `series` is not of type `pd.Series`
             * `offset` is not of type `pd.Timedelta` or `int`
+            * `weekday` is not of type `int` (`bool` is not accepted)
         ValueError: If `weekday` is not an integer between 1 and 7
 
     Examples:
@@ -174,6 +175,12 @@ def isoweek_to_datetime(
     """
     if not isinstance(offset, (pd.Timedelta, int)):
         msg = f"`offset` must be of type `pd.Timedelta` or `int`, found {type(offset)}"
+        raise TypeError(msg)
+
+    # `bool` is excluded explicitly: `isinstance(True, int)` and `True in range(1, 8)` both hold, so
+    # a bare range check would interpolate the literal string "True" into the value being parsed.
+    if not isinstance(weekday, int) or isinstance(weekday, bool):
+        msg = f"`weekday` must be an integer between 1 and 7, found {type(weekday)}"
         raise TypeError(msg)
 
     if weekday not in range(1, 8):

--- a/src/iso_week_date/polars_utils.py
+++ b/src/iso_week_date/polars_utils.py
@@ -195,6 +195,7 @@ def isoweek_to_datetime(
 
             * `series` is not of type `pl.Series` or `pl.Expr`
             * `offset` is not of type `timedelta` or `int`
+            * `weekday` is not of type `int` (`bool` is not accepted)
         ValueError: If `weekday` is not an integer between 1 and 7
 
     Examples:
@@ -214,6 +215,12 @@ def isoweek_to_datetime(
     """
     if not isinstance(offset, (timedelta, int)):
         msg = f"`offset` must be of type `timedelta` or `int`, found {type(offset)}"
+        raise TypeError(msg)
+
+    # `bool` is excluded explicitly: `isinstance(True, int)` and `True in range(1, 8)` both hold, so
+    # a bare range check would interpolate the literal string "True" into the value being parsed.
+    if not isinstance(weekday, int) or isinstance(weekday, bool):
+        msg = f"`weekday` must be an integer between 1 and 7, found {type(weekday)}"
         raise TypeError(msg)
 
     if weekday not in range(1, 8):

--- a/tests/frame_utils/pandas_test.py
+++ b/tests/frame_utils/pandas_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import date, timedelta
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -182,16 +183,20 @@ def test_isoweek_to_datetime_raise(kwargs: dict[str, Any], expected_exception: t
         (
             {"series": pd.Series(["2023-W01-a", "2023-W02-b"]), "offset": 1},
             ValueError,
-            'time data "2023-W01-a-1" doesn\'t match format',
+            'time data "2023-W01-a" doesn\'t match format',
         ),
     ],
 )
 def test_isoweekdate_to_datetime_raise(
     kwargs: dict[str, Any], expected_exception: type[Exception], err_msg: str
 ) -> None:
-    """Test isoweekdate_to_datetime with invalid arguments"""
+    """Test isoweekdate_to_datetime with invalid arguments.
+
+    This called `isoweek_to_datetime` until the `offset` guard here showed up as the only uncovered
+    branch in the module, so the sibling function was being tested twice and this one not at all.
+    """
     with pytest.raises(expected_exception=expected_exception, match=err_msg):
-        isoweek_to_datetime(**kwargs)
+        isoweekdate_to_datetime(**kwargs)
 
 
 @pytest.mark.parametrize(
@@ -277,3 +282,16 @@ def test_is_isoweek_series_raise() -> None:
     series = pd.DataFrame({"isoweek": ["2023-W01", "2023-W02"]})
     with pytest.raises(TypeError):
         is_isoweek_series(series)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("weekday", [1.0, True, False, "1", Decimal(1)])
+def test_isoweek_to_datetime_rejects_non_int_weekday(weekday: Any) -> None:
+    """A non-`int` `weekday` must fail as a `TypeError` before it reaches the parser.
+
+    Left unguarded, each of these is concatenated into the value and surfaces as an opaque pandas
+    parse error about the data rather than about the argument. `bool` is the sharp edge:
+    `isinstance(True, int)` holds and `True in range(1, 8)` holds, so `True` used to be interpolated
+    as the literal string "True", producing `"2023-W01-True"`.
+    """
+    with pytest.raises(TypeError, match=re.escape("`weekday` must be an integer between 1 and 7")):
+        isoweek_to_datetime(pd.Series(["2023-W01", "2023-W02"]), weekday=weekday)

--- a/tests/frame_utils/polars_test.py
+++ b/tests/frame_utils/polars_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -291,3 +292,58 @@ def test_is_isoweek_series_raise() -> None:
     series = pl.DataFrame({"isoweek": ["2023-W01", "2023-W02"]})
     with pytest.raises(TypeError):
         is_isoweek_series(series)  # type: ignore[type-var]
+
+
+@pytest.mark.parametrize("weekday", [1.0, True, False, "1", Decimal(1)])
+def test_isoweek_to_datetime_rejects_non_int_weekday(weekday: Any) -> None:
+    """A non-`int` `weekday` must fail as a `TypeError` before it reaches the parser.
+
+    Left unguarded, each of these is concatenated into the value and surfaces as an
+    `InvalidOperationError` about the data rather than about the argument. `bool` is the sharp edge:
+    `isinstance(True, int)` holds and `True in range(1, 8)` holds, so `True` used to be interpolated
+    as the literal string "True", producing `"2023-W01-True"`.
+    """
+    with pytest.raises(TypeError, match="`weekday` must be an integer between 1 and 7"):
+        isoweek_to_datetime(pl.Series(["2023-W01", "2023-W02"]), weekday=weekday)
+
+
+@pytest.mark.parametrize("check", [is_isoweek_series, is_isoweekdate_series])
+@pytest.mark.parametrize(
+    "values",
+    [
+        ["2023-W01", "2023-W02"],
+        ["2023-W01-1", "2023-W02-1"],
+        ["nope", "2023-W02"],
+        # Nulls are skipped in the lazy path exactly as in the eager one.
+        ["2023-W01", None],
+        ["2023-W01-1", None],
+        [None, None],
+        [],
+    ],
+)
+def test_is_isoweek_checks_accept_an_expr(check: Any, values: list[str | None]) -> None:
+    """The checks accept a `pl.Expr` and answer inside `select`, agreeing with the eager path.
+
+    An `Expr` input yields a boolean `Expr`, not a `bool`: nothing is evaluated until the frame runs
+    it, so `if check(pl.col(...)):` raises on the ambiguous truth value of an `Expr`. That is pinned
+    here because it contradicts the `-> bool` annotation, which is the open item F1 addresses. The
+    eager result is the oracle, so the two paths cannot drift apart unnoticed.
+    """
+    df = pl.DataFrame({"a": pl.Series(values, dtype=pl.String)})
+
+    expr = check(pl.col("a"))
+    assert isinstance(expr, pl.Expr)
+
+    assert df.select(result=expr)["result"].item() == check(df["a"])
+
+
+def test_is_isoweek_checks_via_expr_namespace() -> None:
+    """The registered `iwd` namespace behaves the same on the `Expr` side."""
+    df = pl.DataFrame({"isoweek": ["2023-W01", "2023-W02"], "other": ["nope", "2023-W02"]})
+
+    result = df.select(
+        good=pl.col("isoweek").iwd.is_isoweek(),  # type: ignore[attr-defined]
+        bad=pl.col("other").iwd.is_isoweek(),  # type: ignore[attr-defined]
+    )
+    assert result["good"].item() is True
+    assert result["bad"].item() is False

--- a/tests/isoweek/conversion_test.py
+++ b/tests/isoweek/conversion_test.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from contextlib import nullcontext as do_not_raise
-from typing import TYPE_CHECKING, Final
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Final
 
 import pytest
 
@@ -18,11 +19,18 @@ value: Final[str] = "2023-W01"
         (1.0, TypeError, "`weekday` must be an integer"),
         (-1, ValueError, "Weekday must be between 1 and 7"),
         (8, ValueError, "Weekday must be between 1 and 7"),
+        # `int` lookalikes must be rejected up front rather than interpolated into the value and
+        # failing later as an opaque strptime error. `bool` is the sharp edge: `isinstance(True, int)`
+        # holds and `True in range(1, 8)` holds, so it used to reach strptime as the string "True".
+        (True, TypeError, "`weekday` must be an integer"),
+        (False, TypeError, "`weekday` must be an integer"),
+        ("1", TypeError, "`weekday` must be an integer"),
+        (Decimal(1), TypeError, "`weekday` must be an integer"),
     ],
 )
 def test_to_datetime_raise(
     isoweek_constructor: type[IsoWeek],
-    weekday: int,
+    weekday: Any,
     expected_exception: type[Exception] | None,
     err_msg: str | None,
 ) -> None:

--- a/tests/isoweek/properties_test.py
+++ b/tests/isoweek/properties_test.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from contextlib import nullcontext as do_not_raise
 from datetime import date
-from typing import TYPE_CHECKING, Final
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Final
 
 import pytest
 
@@ -35,11 +36,17 @@ def test_properties(isoweek_constructor: type[IsoWeek]) -> None:
         (1.0, TypeError, "`n` must be an integer"),
         (-1, ValueError, "`n` must be between 1 and 7"),
         (8, ValueError, "`n` must be between 1 and 7"),
+        # `bool` is rejected here as well, so that the weekday-shaped arguments across the class
+        # agree on what an integer is. `nth(True)` used to silently mean `nth(1)`.
+        (True, TypeError, "`n` must be an integer"),
+        (False, TypeError, "`n` must be an integer"),
+        ("1", TypeError, "`n` must be an integer"),
+        (Decimal(1), TypeError, "`n` must be an integer"),
     ],
 )
 def test_nth(
     isoweek_constructor: type[IsoWeek],
-    n: int,
+    n: Any,
     expected_exception: type[Exception] | None,
     err_msg: str | None,
 ) -> None:

--- a/tests/isoweekdate/daysout_test.py
+++ b/tests/isoweekdate/daysout_test.py
@@ -18,9 +18,9 @@ value: Final[str] = "2023-W01-1"
         (1, 1, None, None),
         (1, 2, None, None),
         (10, 1, None, None),
-        (1.0, 1, TypeError, "`n_weeks` must be integer"),
-        (0, 1, ValueError, "`n_weeks` must be strictly positive"),
-        (-2, 1, ValueError, "`n_weeks` must be strictly positive"),
+        (1.0, 1, TypeError, "`n_days` must be integer"),
+        (0, 1, ValueError, "`n_days` must be strictly positive"),
+        (-2, 1, ValueError, "`n_days` must be strictly positive"),
     ],
 )
 def test_daysout(


### PR DESCRIPTION
**Fixes**:

* daysout errors now name `n_days` instead of `n_weeks`
* `IsoWeekDate.to_compact` documents `YYYYWNND`
* a non-int weekday (including bool) fails as a clear `TypeError` in both dataframe backends and the scalar API rather than as an opaque parse error on "2023-W01-True".

**Tests**:

* pl.Expr coverage for the format checks
* non-int weekday cases in both backends, 
* `isoweekdate_to_datetime` offset guard, which was uncovered because its test was calling the sibling function.

**Breaking change** (but correctness fix): `IsoWeek.nth(True)` now raises instead of silently meaning `nth(1)`.