### PR TITLE
fix: Type polars checks per input kind and answer dtype-encoded strings correctly

### DIFF
--- a/docs/user-guide/dataframe-modules.md
+++ b/docs/user-guide/dataframe-modules.md
@@ -32,6 +32,15 @@ convention:
     empty or all-null is also `True`, since it contains nothing that violates the format. A null
     does not excuse a genuine non-match elsewhere, so `["nope", None]` is still `False`.
 
+### Dtype handling
+
+The checks answer on the **content** of a string column, not on the exact dtype holding it. A
+dictionary-encoded column (pandas `category`, polars `Categorical` / `Enum`) is read like any other
+string column, and an all-null column needs no explicit string dtype to be recognised as such.
+
+A non-null value that is not a string is malformed data, not missing data, so a column holding
+lists, dicts or numbers is `False` rather than an error.
+
 !!! warning "The checks validate the format, not the calendar"
     `is_isoweek_series` and `is_isoweekdate_series` test the string pattern, so weeks `01` through
     `53` all pass. They do not check the week number against the year: `2023-W53` passes even though
@@ -215,6 +224,24 @@ df = pl.DataFrame({"date": [date(2023, 1, 1), date(2023, 1, 8)]}).with_columns(
 
 print(df)
 ```
+
+The format checks follow the type of what they are given. A `Series` is data, so it is evaluated on
+the spot and the answer is a `bool`. An `Expr` is not data, so the answer is a boolean `Expr` that
+whatever context receives it evaluates:
+
+```python exec="true" source="material-block" session="df-expr" result="python"
+from iso_week_date.polars_utils import is_isoweek_series
+
+weeks = pl.DataFrame({"week": ["2023-W01", "nope"]})
+
+print(is_isoweek_series(weeks["week"]))  # a Series in, a bool out
+print(type(is_isoweek_series(pl.col("week"))).__name__)  # an Expr in, an Expr out
+print(weeks.select(all_valid=is_isoweek_series(pl.col("week"))))
+```
+
+!!! warning "An expression result is not a `bool`"
+    `if is_isoweek_series(pl.col("week")):` raises `TypeError`, because the truth value of an `Expr`
+    is ambiguous. Evaluate it in a context first, or pass a `Series` when you want an answer now.
 
 ## Custom offsets
 

--- a/src/iso_week_date/pandas_utils.py
+++ b/src/iso_week_date/pandas_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from iso_week_date._patterns import ISOWEEK__DATE_FORMAT, ISOWEEK_PATTERN, ISOWEEKDATE__DATE_FORMAT, ISOWEEKDATE_PATTERN
 from iso_week_date._utils import require_version
@@ -237,7 +237,7 @@ def isoweekdate_to_datetime(
     return pd.to_datetime(series, errors=errors, format=ISOWEEKDATE__DATE_FORMAT) + _offset
 
 
-def _match_series(series: pd.Series[str], pattern: str) -> bool:
+def _match_series(series: pd.Series[Any], pattern: str) -> bool:
     """Checks if a `series` contains only values matching `pattern`.
 
     Null values are skipped rather than counted as non-matching, so a series of
@@ -252,6 +252,11 @@ def _match_series(series: pd.Series[str], pattern: str) -> bool:
 
     `str.fullmatch` is used rather than `str.match` for the reason spelled out in
     `iso_week_date._utils.match_isoweek`: `str.match` would accept a trailing newline.
+
+    The match result is filled with `False` because an `object` series can hold values that are
+    neither null nor `str` (a list, a dict, a number alongside strings). `str.fullmatch` returns
+    `NaN` for those, and `NaN` is truthy, so an unfilled `all()` reported a series of lists as
+    correctly formatted. Only nulls in the *input* are excused, and those are masked out separately.
 
     Arguments:
         series: Series of `str` values
@@ -270,13 +275,16 @@ def _match_series(series: pd.Series[str], pattern: str) -> bool:
 
     try:
         matches = series.str.fullmatch(pattern)
-    except AttributeError:
+    except (AttributeError, TypeError):
+        # `AttributeError` for a dtype with no `.str` accessor at all, `TypeError` for one that has
+        # it but cannot match against it (`bytes` values). Neither holds ISO Week strings, so both
+        # are a plain `False`: the only `TypeError` this function raises is for a non-`pd.Series`.
         return False
 
-    return bool(matches[series.notna()].all())
+    return bool(matches[series.notna()].fillna(value=False).all())
 
 
-def is_isoweek_series(series: pd.Series[str]) -> bool:
+def is_isoweek_series(series: pd.Series[Any]) -> bool:
     """Checks if `series` contains only values in ISO Week format.
 
     Arguments:
@@ -299,7 +307,7 @@ def is_isoweek_series(series: pd.Series[str]) -> bool:
     return _match_series(series, ISOWEEK_PATTERN.pattern)
 
 
-def is_isoweekdate_series(series: pd.Series[str]) -> bool:
+def is_isoweekdate_series(series: pd.Series[Any]) -> bool:
     """Checks if `series` contains only values in ISO Week date format.
 
     Arguments:
@@ -483,7 +491,7 @@ class SeriesIsoWeek:
             >>> s.iwd.is_isoweek()
             True
         """
-        return is_isoweek_series(self._series)  # type: ignore[arg-type]
+        return is_isoweek_series(self._series)
 
     def is_isoweekdate(self: Self) -> bool:
         """Checks if series contains only values in ISO Week date format.
@@ -499,4 +507,4 @@ class SeriesIsoWeek:
             >>> s.iwd.is_isoweekdate()
             True
         """
-        return is_isoweekdate_series(self._series)  # type: ignore[arg-type]
+        return is_isoweekdate_series(self._series)

--- a/src/iso_week_date/polars_utils.py
+++ b/src/iso_week_date/polars_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, overload
 
 from iso_week_date._patterns import ISOWEEK__DATE_FORMAT, ISOWEEK_PATTERN, ISOWEEKDATE__DATE_FORMAT, ISOWEEKDATE_PATTERN
 from iso_week_date._utils import require_version
@@ -9,6 +9,7 @@ from iso_week_date._utils import require_version
 require_version("polars", minimum="0.18.0", extra="polars")
 
 import polars as pl  # noqa: E402
+from polars.exceptions import ComputeError, InvalidOperationError, SchemaError  # noqa: E402
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -281,8 +282,20 @@ def isoweekdate_to_datetime(
     return series.str.strptime(pl.Date, ISOWEEKDATE__DATE_FORMAT, strict=strict) + _offset
 
 
-def _match_series(series: ExprOrSeries, pattern: str) -> bool:
+@overload
+def _match_series(series: pl.Series, pattern: str) -> bool: ...
+
+
+@overload
+def _match_series(series: pl.Expr, pattern: str) -> pl.Expr: ...
+
+
+def _match_series(series: pl.Series | pl.Expr, pattern: str) -> bool | pl.Expr:
     """Checks if a `Series` or `Expr` contains only values matching `pattern`.
+
+    A `pl.Series` is evaluated eagerly and gives back a `bool`. A `pl.Expr` cannot be: it describes a
+    computation with no data attached yet, so it gives back a boolean `Expr` to be evaluated by
+    whatever `select` / `filter` / `with_columns` it is handed to.
 
     Null values are skipped rather than counted as non-matching, so a series of
     `["2024-W01", None]` returns `True`. A null is missing data, not a malformed ISO Week string,
@@ -292,13 +305,21 @@ def _match_series(series: ExprOrSeries, pattern: str) -> bool:
     `fill_null(True)` states that intent rather than leaning on `all()` ignoring nulls by default,
     so the behaviour cannot silently flip if that default ever changes.
 
+    The cast to `String` is what lets `Categorical` and `Enum` columns be checked: they hold genuine
+    ISO Week strings, but `str.contains` refuses to look at them and raises. It also settles the
+    `Null` dtype, where an all-null series is missing data rather than malformed data. For any dtype
+    that is not string-like the cast either fails or yields values that cannot match, so the answer
+    stays `False` either way. `String` rather than `String` because the latter does not exist on the
+    declared polars floor.
+
     Arguments:
         series: Series or Expr of `str` values
         pattern: pattern to match. It is already anchored by `iso_week_date._patterns`.
 
     Returns:
-        `True` if all non-null values match `pattern`, `False` otherwise. An empty or all-null
-            series returns `True`, since it contains nothing that violates the format.
+        For a `pl.Series`, `True` if all non-null values match `pattern` and `False` otherwise; an
+            empty or all-null series returns `True`, since it contains nothing that violates the
+            format. For a `pl.Expr`, a boolean `Expr` computing the same answer.
 
     Raises:
         TypeError: If `series` is not of type `pl.Series` or `pl.Expr`
@@ -308,19 +329,35 @@ def _match_series(series: ExprOrSeries, pattern: str) -> bool:
         raise TypeError(msg)
 
     try:
-        return series.str.contains(pattern).fill_null(value=True).all()  # type: ignore[return-value]
-    except Exception:  # noqa: BLE001
+        return series.cast(pl.String()).str.contains(pattern).fill_null(value=True).all()
+    except (InvalidOperationError, SchemaError, ComputeError):
+        # A dtype that is neither string-like nor castable to one (nested types, for instance) holds
+        # nothing in ISO Week format, so it is a plain `False` rather than an error. Narrowed to the
+        # dtype and compute failures on purpose: a bare `except` here would report a genuine bug in
+        # this function as "not ISO Week format". Only the eager path can reach this at all; for an
+        # `Expr` nothing is evaluated yet, so the equivalent failure surfaces from the frame.
         return False
 
 
-def is_isoweek_series(series: ExprOrSeries) -> bool:
+@overload
+def is_isoweek_series(series: pl.Series) -> bool: ...
+
+
+@overload
+def is_isoweek_series(series: pl.Expr) -> pl.Expr: ...
+
+
+def is_isoweek_series(series: pl.Series | pl.Expr) -> bool | pl.Expr:
     """Checks if a series or expr contains only values in ISO Week format.
 
     Arguments:
         series: series or expr of `str` values to check against "YYYY-WNN" pattern
 
     Returns:
-        `True` if all values match ISO Week format, `False` otherwise
+        For a `pl.Series`, `True` if all values match ISO Week format and `False` otherwise. For a
+            `pl.Expr`, a boolean `Expr` computing the same answer, to be used inside `select` /
+            `filter`. An `Expr` is not a `bool`, so `if is_isoweek_series(expr):` raises on its
+            ambiguous truth value.
 
     Raises:
         TypeError: If `series` is not of type `pl.Series` or `pl.Expr`
@@ -332,18 +369,35 @@ def is_isoweek_series(series: ExprOrSeries) -> bool:
         >>> s = pl.Series(["2022-W52", "2023-W01", "2023-W02"])
         >>> is_isoweek_series(s)
         True
+
+        The `Expr` form answers inside a frame:
+
+        >>> df = pl.DataFrame({"isoweek": ["2022-W52", "2023-W01"]})
+        >>> df.select(is_isoweek=is_isoweek_series(pl.col("isoweek")))["is_isoweek"].item()
+        True
     """
     return _match_series(series, ISOWEEK_PATTERN.pattern)
 
 
-def is_isoweekdate_series(series: ExprOrSeries) -> bool:
+@overload
+def is_isoweekdate_series(series: pl.Series) -> bool: ...
+
+
+@overload
+def is_isoweekdate_series(series: pl.Expr) -> pl.Expr: ...
+
+
+def is_isoweekdate_series(series: pl.Series | pl.Expr) -> bool | pl.Expr:
     """Checks if a series or expr contains only values in ISO Week date format.
 
     Arguments:
         series: series or expr of `str` values to check against "YYYY-WNN-D" pattern
 
     Returns:
-        `True` if all values match ISO Week date format, `False` otherwise
+        For a `pl.Series`, `True` if all values match ISO Week date format and `False` otherwise. For
+            a `pl.Expr`, a boolean `Expr` computing the same answer, to be used inside `select` /
+            `filter`. An `Expr` is not a `bool`, so `if is_isoweekdate_series(expr):` raises on its
+            ambiguous truth value.
 
     Raises:
         TypeError: If `series` is not of type `pl.Series` or `pl.Expr`
@@ -354,6 +408,12 @@ def is_isoweekdate_series(series: ExprOrSeries) -> bool:
         >>>
         >>> s = pl.Series(["2022-W52-1", "2023-W01-1", "2023-W02-1"])
         >>> is_isoweekdate_series(series=s)
+        True
+
+        The `Expr` form answers inside a frame:
+
+        >>> df = pl.DataFrame({"isoweekdate": ["2022-W52-1", "2023-W01-1"]})
+        >>> df.select(check=is_isoweekdate_series(pl.col("isoweekdate")))["check"].item()
         True
     """
     return _match_series(series, ISOWEEKDATE_PATTERN.pattern)
@@ -561,11 +621,19 @@ class SeriesIsoWeek(Generic[ExprOrSeries]):
         """
         return isoweekdate_to_datetime(self._series, offset=offset, strict=strict)
 
-    def is_isoweek(self: Self) -> bool:
+    @overload
+    def is_isoweek(self: SeriesIsoWeek[pl.Series]) -> bool: ...
+
+    @overload
+    def is_isoweek(self: SeriesIsoWeek[pl.Expr]) -> pl.Expr: ...
+
+    def is_isoweek(self: Self) -> bool | pl.Expr:
         """Checks if a series or expr contains only values in ISO Week format.
 
         Returns:
-            `True` if all values match ISO Week format, `False` otherwise
+            For a `pl.Series`, `True` if all values match ISO Week format and `False` otherwise. For
+                a `pl.Expr`, a boolean `Expr` computing the same answer, to be used inside `select` /
+                `filter`.
 
         Examples:
             >>> import polars as pl
@@ -574,14 +642,26 @@ class SeriesIsoWeek(Generic[ExprOrSeries]):
             >>> s = pl.Series(["2022-W52", "2023-W01", "2023-W02"])
             >>> s.iwd.is_isoweek()
             True
+
+            >>> df = pl.DataFrame({"isoweek": ["2022-W52", "2023-W01"]})
+            >>> df.select(check=pl.col("isoweek").iwd.is_isoweek())["check"].item()
+            True
         """
         return is_isoweek_series(self._series)
 
-    def is_isoweekdate(self: Self) -> bool:
+    @overload
+    def is_isoweekdate(self: SeriesIsoWeek[pl.Series]) -> bool: ...
+
+    @overload
+    def is_isoweekdate(self: SeriesIsoWeek[pl.Expr]) -> pl.Expr: ...
+
+    def is_isoweekdate(self: Self) -> bool | pl.Expr:
         """Checks if a series or expr contains only values in ISO Week date format.
 
         Returns:
-            `True` if all values match ISO Week date format, `False` otherwise
+            For a `pl.Series`, `True` if all values match ISO Week date format and `False` otherwise.
+                For a `pl.Expr`, a boolean `Expr` computing the same answer, to be used inside
+                `select` / `filter`.
 
         Examples:
             >>> import polars as pl
@@ -589,6 +669,10 @@ class SeriesIsoWeek(Generic[ExprOrSeries]):
             >>>
             >>> s = pl.Series(["2022-W52-1", "2023-W01-1", "2023-W02-1"])
             >>> s.iwd.is_isoweekdate()
+            True
+
+            >>> df = pl.DataFrame({"isoweekdate": ["2022-W52-1", "2023-W01-1"]})
+            >>> df.select(check=pl.col("isoweekdate").iwd.is_isoweekdate())["check"].item()
             True
         """
         return is_isoweekdate_series(self._series)

--- a/tests/frame_utils/pandas_test.py
+++ b/tests/frame_utils/pandas_test.py
@@ -284,6 +284,34 @@ def test_is_isoweek_series_raise() -> None:
         is_isoweek_series(series)  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("series", "expected"),
+    [
+        # A `category` column holds ordinary strings and is read on its content, as in polars.
+        (pd.Series(["2023-W01"], dtype="category"), True),
+        (pd.Series(["2023-W01", None], dtype="category"), True),
+        (pd.Series(["nope"], dtype="category"), False),
+        # A non-null value that is not a `str` is malformed data. `str.fullmatch` yields `NaN` for
+        # those and `NaN` is truthy, so an unfilled `all()` used to call them correctly formatted.
+        (pd.Series([["2023-W01"], ["2023-W02"]], dtype="object"), False),
+        (pd.Series([{"a": 1}], dtype="object"), False),
+        (pd.Series(["2023-W01", 1], dtype="object"), False),
+        # The dangerous one: a real ISO Week string beside a value that is not a string at all.
+        (pd.Series([["2023-W01"], "2023-W01"], dtype="object"), False),
+        # `bytes` has a `.str` accessor that cannot match, raising `TypeError` rather than
+        # `AttributeError`; the only `TypeError` these functions raise is for a non-`pd.Series`.
+        (pd.Series([b"2023-W01"], dtype="object"), False),
+        # No `.str` accessor at all.
+        (pd.Series([1, 2, 3]), False),
+        (pd.Series([1.5]), False),
+        (pd.Series([True, False]), False),
+    ],
+)
+def test_is_isoweek_series_answers_on_content_not_dtype(series: pd.Series, expected: bool) -> None:
+    """Both checks share `_match_series`, so dtype handling is exercised through one of them."""
+    assert is_isoweek_series(series) is expected
+
+
 @pytest.mark.parametrize("weekday", [1.0, True, False, "1", Decimal(1)])
 def test_isoweek_to_datetime_rejects_non_int_weekday(weekday: Any) -> None:
     """A non-`int` `weekday` must fail as a `TypeError` before it reaches the parser.

--- a/tests/frame_utils/parity_test.py
+++ b/tests/frame_utils/parity_test.py
@@ -8,6 +8,7 @@ test file. These tests assert the two backends agree on the same inputs.
 from __future__ import annotations
 
 from datetime import date
+from typing import Any
 
 import pytest
 
@@ -71,6 +72,46 @@ def test_is_isoweekdate_series_parity(values: list[str | None], expected: bool) 
 
     assert pandas_result == polars_result, f"backends disagree on {values!r}"
     assert pandas_result == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (["2023-W01", "2023-W02"], True),
+        (["2023-W01", "nope"], False),
+    ],
+)
+def test_is_isoweek_series_parity_for_dictionary_encoded_strings(values: list[str], expected: bool) -> None:
+    """pandas `category` and polars `Categorical` / `Enum` hold plain strings, so both read content.
+
+    This is the case where the backends disagreed outright: `str.contains` rejects these dtypes and
+    the failure was swallowed, so polars answered `False` for every one of them.
+    """
+    assert pandas_utils.is_isoweek_series(pd.Series(values, dtype="category")) is expected
+    assert polars_utils.is_isoweek_series(pl.Series(values, dtype=pl.Categorical)) is expected
+    assert polars_utils.is_isoweek_series(pl.Series(values, dtype=pl.Enum(values))) is expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        # An all-null column is missing data in both, with no explicit string dtype spelled out.
+        ([None, None], True),
+        # Non-`str` values are malformed data in both. They failed in opposite directions: polars
+        # swallowed a dtype error into `False` (right answer, wrong reason) while pandas turned
+        # `str.fullmatch`'s `NaN` into a truthy `True`.
+        ([["2023-W01"], ["2023-W02"]], False),
+        ([{"a": 1}], False),
+        ([1, 2, 3], False),
+    ],
+)
+def test_is_isoweek_series_parity_beyond_string_columns(values: list[Any], expected: bool) -> None:
+    """The backends agree on columns whose values are not plain strings."""
+    pandas_result = pandas_utils.is_isoweek_series(pd.Series(values))
+    polars_result = polars_utils.is_isoweek_series(pl.Series(values))
+
+    assert pandas_result == polars_result, f"backends disagree on {values!r}"
+    assert pandas_result is expected
 
 
 def test_conversions_propagate_nulls_identically() -> None:

--- a/tests/frame_utils/polars_test.py
+++ b/tests/frame_utils/polars_test.py
@@ -11,11 +11,12 @@ pytest.importorskip("polars")
 import polars as pl
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
+from typing_extensions import assert_type
 
 from iso_week_date import IsoWeek, IsoWeekDate
 from iso_week_date._patterns import ISOWEEK__DATE_FORMAT, ISOWEEKDATE__DATE_FORMAT
 from iso_week_date.polars_utils import (
-    SeriesIsoWeek,  # noqa: F401
+    SeriesIsoWeek,
     _datetime_to_format,
     datetime_to_isoweek,
     datetime_to_isoweekdate,
@@ -291,7 +292,7 @@ def test_is_isoweek_series_raise() -> None:
     """Test is_isoweek_series function with invalid type"""
     series = pl.DataFrame({"isoweek": ["2023-W01", "2023-W02"]})
     with pytest.raises(TypeError):
-        is_isoweek_series(series)  # type: ignore[type-var]
+        is_isoweek_series(series)  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize("weekday", [1.0, True, False, "1", Decimal(1)])
@@ -309,32 +310,90 @@ def test_isoweek_to_datetime_rejects_non_int_weekday(weekday: Any) -> None:
 
 @pytest.mark.parametrize("check", [is_isoweek_series, is_isoweekdate_series])
 @pytest.mark.parametrize(
-    "values",
+    "series",
     [
-        ["2023-W01", "2023-W02"],
-        ["2023-W01-1", "2023-W02-1"],
-        ["nope", "2023-W02"],
-        # Nulls are skipped in the lazy path exactly as in the eager one.
-        ["2023-W01", None],
-        ["2023-W01-1", None],
-        [None, None],
-        [],
+        pl.Series(["2023-W01", "2023-W02"], dtype=pl.String),
+        pl.Series(["2023-W01-1", "2023-W02-1"], dtype=pl.String),
+        pl.Series(["nope", "2023-W02"], dtype=pl.String),
+        pl.Series(["2023-W01", None], dtype=pl.String),
+        pl.Series([None, None], dtype=pl.String),
+        pl.Series([], dtype=pl.String),
+        # The dtypes the cast exists for must answer the same way lazily.
+        pl.Series(["2023-W01", "2023-W02"], dtype=pl.Categorical),
+        pl.Series([None, None]),
+        pl.Series([1, 2, 3]),
     ],
 )
-def test_is_isoweek_checks_accept_an_expr(check: Any, values: list[str | None]) -> None:
-    """The checks accept a `pl.Expr` and answer inside `select`, agreeing with the eager path.
-
-    An `Expr` input yields a boolean `Expr`, not a `bool`: nothing is evaluated until the frame runs
-    it, so `if check(pl.col(...)):` raises on the ambiguous truth value of an `Expr`. That is pinned
-    here because it contradicts the `-> bool` annotation, which is the open item F1 addresses. The
-    eager result is the oracle, so the two paths cannot drift apart unnoticed.
-    """
-    df = pl.DataFrame({"a": pl.Series(values, dtype=pl.String)})
-
+def test_is_isoweek_checks_accept_an_expr(check: Any, series: pl.Series) -> None:
+    """An `Expr` in gives a boolean `Expr` out, computing exactly what the eager path computes."""
     expr = check(pl.col("a"))
-    assert isinstance(expr, pl.Expr)
+    assert isinstance(expr, pl.Expr), "an Expr is not a bool: `if check(expr):` would raise"
 
-    assert df.select(result=expr)["result"].item() == check(df["a"])
+    assert pl.DataFrame({"a": series}).select(result=expr)["result"].item() == check(series)
+
+
+@pytest.mark.parametrize(
+    ("series", "expected"),
+    [
+        # Dictionary-encoded strings are still strings: `str.contains` rejects the dtype and used to
+        # be swallowed into `False`, a wrong answer for a valid column.
+        (pl.Series(["2023-W01", "2023-W02"], dtype=pl.Categorical), True),
+        (pl.Series(["2023-W01", None], dtype=pl.Categorical), True),
+        (pl.Series(["nope"], dtype=pl.Categorical), False),
+        (pl.Series(["2023-W01"], dtype=pl.Enum(["2023-W01"])), True),
+        (pl.Series(["2023-W01", None], dtype=pl.Enum(["2023-W01"])), True),
+        (pl.Series([], dtype=pl.Categorical), True),
+        # `Null`, not `String`: an all-null column needs no explicit string dtype to be recognised
+        # as containing nothing that violates the format.
+        (pl.Series([None, None]), True),
+        (pl.Series([]), True),
+        # Not string-like: malformed data, so `False` rather than an error. Three different routes
+        # get there: the cast succeeds but nothing matches, the cast raises `InvalidOperationError`
+        # (nested types), or the cast raises `ComputeError` (`Object`).
+        (pl.Series([1, 2, 3]), False),
+        (pl.Series([1.5]), False),
+        (pl.Series([True, False]), False),
+        (pl.Series([date(2023, 1, 2)]), False),
+        (pl.Series([{"a": 1}]), False),
+        (pl.Series([["2023-W01"]]), False),
+        (pl.Series([["2023-W01"]], dtype=pl.Array(pl.String, 1)), False),
+        (pl.Series([object()], dtype=pl.Object), False),
+        # `Binary` is the one dtype the cast decodes into a matching string, so bytes spelling an ISO
+        # week read as `True` here while pandas answers `False`. Restricting the cast per dtype would
+        # fix the asymmetry but is impossible for an `Expr`, whose dtype is unknown until collection,
+        # and an eager/lazy split inside one backend is the worse trade.
+        (pl.Series([b"2023-W01"]), True),
+    ],
+)
+def test_is_isoweek_series_answers_on_content_not_dtype(series: pl.Series, expected: bool) -> None:
+    """Both checks share `_match_series`, so dtype handling is exercised through one of them."""
+    assert is_isoweek_series(series) is expected
+
+
+def test_is_isoweek_series_nested_dtype_is_eager_only() -> None:
+    """The `except` cannot fire for an `Expr`, so a nested column is `False` eagerly and raises lazily."""
+    series = pl.Series([["2023-W01"]])
+
+    assert is_isoweek_series(series) is False
+    with pytest.raises(InvalidOperationError, match="cannot cast List type"):
+        pl.DataFrame({"a": series}).select(check=is_isoweek_series(pl.col("a")))
+
+
+def test_is_isoweek_checks_are_typed_per_input_kind() -> None:
+    """`assert_type` is checked by mypy and pyright, both of which run over `tests/`."""
+    series, expr = pl.Series(["2023-W01"]), pl.col("isoweek")
+
+    assert_type(is_isoweek_series(series), bool)
+    assert_type(is_isoweek_series(expr), pl.Expr)
+    assert_type(is_isoweekdate_series(series), bool)
+    assert_type(is_isoweekdate_series(expr), pl.Expr)
+
+    # Through the class rather than the `.iwd` accessor: polars registers the namespace at runtime,
+    # so the accessor is `Any` to a type checker and would assert nothing.
+    assert_type(SeriesIsoWeek(series).is_isoweek(), bool)
+    assert_type(SeriesIsoWeek(expr).is_isoweek(), pl.Expr)
+    assert_type(SeriesIsoWeek(series).is_isoweekdate(), bool)
+    assert_type(SeriesIsoWeek(expr).is_isoweekdate(), pl.Expr)
 
 
 def test_is_isoweek_checks_via_expr_namespace() -> None:


### PR DESCRIPTION
# Description

The polars format checks now declare what they return via overloads:

* `pl.Series` -> `bool`
* `pl.Expr` -> `pl.Expr`